### PR TITLE
Singleton resize observer, pass the resizeObserverEntry in event detail

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,12 +16,11 @@ const resizeObserer = new ResizeObserver((entries) => {
  * Example usage: `<div use:watchResize on:resize={handleResize}></div>`
  *
  * @param HTMLElement node
- * @param String box - sets the observe option for box. Can be set to 'content-box' (default) or 'border-box'
  */
-export default function observeResize(node, box) {
+export default function observeResize(node) {
 
   // Watch for node to resize
-  resizeObserer.observe(node, box && { box } );
+  resizeObserer.observe(node);
 
   return {
     // Called when node is unmounted

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,13 @@
 import ResizeObserver from 'resize-observer-polyfill';
 
+// Singleton observer for all nodes
+const resizeObserer = new ResizeObserver((entries) => {
+  // Dispatch custom event when each node is resized
+  entries.forEach(entry => {
+    entry.target.dispatchEvent(new CustomEvent('resize', { detail: entry }));
+  })
+});
+
 /**
  * Custom Svelte action
  *  - Uses Resize Observer API
@@ -8,15 +16,12 @@ import ResizeObserver from 'resize-observer-polyfill';
  * Example usage: `<div use:watchResize on:resize={handleResize}></div>`
  *
  * @param HTMLElement node
+ * @param String box - sets the observe option for box. Can be set to 'content-box' (default) or 'border-box'
  */
-export default function observeResize(node) {
-  const resizeObserer = new ResizeObserver((entries) => {
-    // Dispatch custom event when node is resized
-    node.dispatchEvent(new CustomEvent('resize'));
-  });
+export default function observeResize(node, box) {
 
   // Watch for node to resize
-  resizeObserer.observe(node);
+  resizeObserer.observe(node, box && { box } );
 
   return {
     // Called when node is unmounted


### PR DESCRIPTION
Love this svelte action implementation you have, thought it needs some critical updates, though.

ResizeObserver is designed to be a single instance and have all nodes added to it. It's more performant this way as well.
In this case, I'm using `resizeObserer` as a singleton closure

Also, the custom event now includes the resizeObserverEntry in the event detail, so we can actually use the data from the fired event!

I can setup a pr for dev example later, if this gets merged.

_Edit: Thanks for this repo, :)_
Edit 2: Removed box option, since there isnt much support...